### PR TITLE
CPU info

### DIFF
--- a/lib/benchee/system.ex
+++ b/lib/benchee/system.ex
@@ -78,9 +78,12 @@ defmodule Benchee.System do
   end
   def parse_cpu_for(:macOS, raw_output), do: String.trim(raw_output)
   def parse_cpu_for(:Linux, raw_output) do
-    ["model name\t:" <> cpu_info] = Regex.run(~r/model name.*:[\w \(\)\-\@\.]*ghz/i, raw_output)
-    String.trim(cpu_info)
+    Regex.run(~r/model name.*:([\w \(\)\-\@\.]*)/i, raw_output, capture: :all_but_first)
+    |> parse_cpu_for_(:Linux)
   end
+
+  defp parse_cpu_for_(_cpu_info = nil,  :Linux), do: "Unrecognized processor"
+  defp parse_cpu_for_([cpu_info],       :Linux), do: String.trim(cpu_info)
 
   @doc """
   Returns an integer with the total number of available memory on the machine


### PR DESCRIPTION
When `benchee` is used on hosted CI tool [`Semaphore`](https://semaphoreci.com/) it is failing with:
```
** (MatchError) no match of right hand side value: nil
    (benchee) lib/benchee/system.ex:81: Benchee.System.parse_cpu_for/2
    (benchee) lib/benchee/system.ex:18: Benchee.System.system/1
...
```

because `cat /proc/cpuinfo` produces:
```
...
model name	: Intel Core Processor (Haswell)
...
```
and regex in `parse_cpu_for(:Linux, raw_output)` expects `model name` to contain `ghz` string.

When `Regex.run` finds no match it returns `nil` and Elixir pattern matching (`=`) expects list so we get `MatchError` exception.

This PR
- relaxes `parse_cpu_for` regex ("ghz" string is not required) and
- gracefully falls back even if CPU description is not recognized.